### PR TITLE
fix: apply k8s manifests sequentially, correct LB IP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,13 @@ jobs:
         run: echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Apply manifests
-        run: kubectl apply -f k8s/
+        run: |
+          kubectl apply -f k8s/namespace.yaml
+          kubectl apply -f k8s/service.yaml
+          kubectl apply -f k8s/deployment.yaml
+          kubectl apply -f k8s/ingress.yaml
+          # dns.yaml requires external-dns CRD; skip if not installed
+          kubectl apply -f k8s/dns.yaml 2>/dev/null || echo "Skipping dns.yaml (CRD not installed)"
 
       - name: Update image
         run: |

--- a/k8s/dns.yaml
+++ b/k8s/dns.yaml
@@ -8,5 +8,5 @@ spec:
     - dnsName: pixelwise.tinyland.dev
       recordType: A
       targets:
-        - 159.203.154.10
+        - 212.2.244.217
       recordTTL: 300


### PR DESCRIPTION
## Summary

- Apply k8s manifests sequentially (namespace first) to avoid race condition
- Correct LB IP in dns.yaml from 159.203.154.10 to 212.2.244.217 (actual Civo LB)
- Gracefully skip dns.yaml if external-dns CRD isn't installed

## Test plan

- [ ] Deploy workflow succeeds on next merge to master
- [ ] Pod continues running after redeployment