### PR TITLE
fix: update domain to pixelwise.ephemera.xoxd.ai

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           sleep 10
           status=$(curl -sf -o /dev/null -w "%{http_code}" \
-            https://pixelwise.tinyland.dev/api/health || true)
+            https://pixelwise.ephemera.xoxd.ai/api/health || true)
           if [ "$status" = "200" ]; then
             echo "Health check passed"
           else

--- a/k8s/dns.yaml
+++ b/k8s/dns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: pixelwise
 spec:
   endpoints:
-    - dnsName: pixelwise.tinyland.dev
+    - dnsName: pixelwise.ephemera.xoxd.ai
       recordType: A
       targets:
         - 212.2.244.217

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -10,10 +10,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - pixelwise.tinyland.dev
-      secretName: pixelwise-tls-secret
+        - pixelwise.ephemera.xoxd.ai
+      secretName: pixelwise-ephemera-tls
   rules:
-    - host: pixelwise.tinyland.dev
+    - host: pixelwise.ephemera.xoxd.ai
       http:
         paths:
           - path: /


### PR DESCRIPTION
## Summary

- Update ingress, DNS, and deploy smoke test from `pixelwise.tinyland.dev` to `pixelwise.ephemera.xoxd.ai`
- Rename TLS secret to `pixelwise-ephemera-tls`

## Test plan

- [ ] DNS resolves `pixelwise.ephemera.xoxd.ai → 212.2.244.217`
- [ ] TLS cert issued by cert-manager
- [ ] `curl https://pixelwise.ephemera.xoxd.ai/api/health` returns 200