### PR TITLE
fix: track favicon.svg, update domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           sleep 10
           status=$(curl -sf -o /dev/null -w "%{http_code}" \
-            https://pixelwise.tinyland.dev/api/health || true)
+            https://pixelwise.ephemera.xoxd.ai/api/health || true)
           if [ "$status" = "200" ]; then
             echo "Health check passed"
           else

--- a/k8s/dns.yaml
+++ b/k8s/dns.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: pixelwise
 spec:
   endpoints:
-    - dnsName: pixelwise.tinyland.dev
+    - dnsName: pixelwise.ephemera.xoxd.ai
       recordType: A
       targets:
         - 212.2.244.217

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -10,10 +10,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - pixelwise.tinyland.dev
-      secretName: pixelwise-tls-secret
+        - pixelwise.ephemera.xoxd.ai
+      secretName: pixelwise-ephemera-tls
   rules:
-    - host: pixelwise.tinyland.dev
+    - host: pixelwise.ephemera.xoxd.ai
       http:
         paths:
           - path: /

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!favicon.svg

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Pixelwise favicon - stylized pixel grid representing WebGPU/WASM processing -->
+  <rect width="32" height="32" rx="4" fill="#1a1a2e"/>
+  <!-- Pixel grid pattern -->
+  <rect x="4" y="4" width="6" height="6" rx="1" fill="#4ade80"/>
+  <rect x="13" y="4" width="6" height="6" rx="1" fill="#22d3ee"/>
+  <rect x="22" y="4" width="6" height="6" rx="1" fill="#a78bfa"/>
+  <rect x="4" y="13" width="6" height="6" rx="1" fill="#f472b6"/>
+  <rect x="13" y="13" width="6" height="6" rx="1" fill="#fbbf24"/>
+  <rect x="22" y="13" width="6" height="6" rx="1" fill="#4ade80"/>
+  <rect x="4" y="22" width="6" height="6" rx="1" fill="#22d3ee"/>
+  <rect x="13" y="22" width="6" height="6" rx="1" fill="#a78bfa"/>
+  <rect x="22" y="22" width="6" height="6" rx="1" fill="#f472b6"/>
+</svg>


### PR DESCRIPTION
## Summary

- Track `favicon.svg` in git (was ignored by `static/.gitignore`)
- Add exception to `static/.gitignore` for favicon

Fixes 404 on deployed site.

## Test plan

- [ ] `https://pixelwise.ephemera.xoxd.ai/favicon.svg` returns 200