### PR TITLE
fix: enforce WebGPU gate, handle WASM OOM and assertion failures

### DIFF
--- a/src/lib/futhark-webgpu/index.ts
+++ b/src/lib/futhark-webgpu/index.ts
@@ -190,6 +190,15 @@ export async function newFutharkWebGPUContext(): Promise<FutharkWebGPUContext> {
 		} catch (err: unknown) {
 			contextPromise = null; // Reset on failure to allow retry
 			const message = err instanceof Error ? err.message : String(err);
+
+			if (message.includes('assert') || message.includes('Assertion') || message.includes('abort')) {
+				throw new Error(
+					`Futhark WebGPU context creation failed (GPU assertion). ` +
+						`This usually means WebGPU is not fully supported by your browser/GPU driver. ` +
+						`Original error: ${message}`
+				);
+			}
+
 			throw new Error(
 				`Failed to initialize Futhark WebGPU context. ` +
 					`Ensure 'just futhark-webgpu-compile' has been run. ` +

--- a/src/lib/utils/consentStorage.ts
+++ b/src/lib/utils/consentStorage.ts
@@ -35,6 +35,8 @@ export interface ConsentData {
 	completedSteps: number[];
 	/** Detected compute backend at onboarding time */
 	detectedBackend: string;
+	/** Whether WebGPU was available at onboarding time */
+	webgpuAvailable: boolean;
 	/** Version of onboarding shown (for future migrations) */
 	version: number;
 }
@@ -48,6 +50,7 @@ const DEFAULT_CONSENT: ConsentData = {
 	paperViewed: false,
 	completedSteps: [],
 	detectedBackend: '',
+	webgpuAvailable: false,
 	version: 2
 };
 
@@ -165,11 +168,31 @@ export function getConsentAge(): number | null {
 	return Math.floor(ageMs / (1000 * 60 * 60 * 24));
 }
 
+/**
+ * Check if demos should be blocked (no WebGPU available)
+ * @returns true if WebGPU is not available and demos should be gated
+ */
+export function shouldBlockDemos(): boolean {
+	if (!browser) return false;
+	const consent = getConsent();
+	if (consent && !consent.webgpuAvailable) return true;
+	return false;
+}
+
+/**
+ * Update the stored WebGPU availability status
+ */
+export function updateWebGPUAvailability(available: boolean): void {
+	setConsent({ webgpuAvailable: available });
+}
+
 export default {
 	getConsent,
 	setConsent,
 	completeOnboarding,
 	shouldShowOnboarding,
+	shouldBlockDemos,
+	updateWebGPUAvailability,
 	resetConsent,
 	getConsentAge
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
 	import { onMount } from 'svelte';
 	import type { Snippet } from 'svelte';
 	import OnboardingModal from '$lib/components/OnboardingModal.svelte';
-	import { shouldShowOnboarding } from '$lib/utils/consentStorage';
+	import { shouldShowOnboarding, shouldBlockDemos } from '$lib/utils/consentStorage';
 
 	interface Props {
 		children: Snippet;
@@ -69,6 +69,15 @@
 
 		// Check if onboarding should be shown
 		showOnboarding = shouldShowOnboarding();
+	});
+
+	// Re-gate on demo route navigation when WebGPU is unavailable
+	$effect(() => {
+		if (browser && initialized && $page.url.pathname.startsWith('/demo')) {
+			if (shouldBlockDemos()) {
+				showOnboarding = true;
+			}
+		}
 	});
 
 	// Reactive effect: Apply dark mode to document.documentElement when isDark changes

--- a/src/routes/demo/+layout.svelte
+++ b/src/routes/demo/+layout.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import DemoSidebar from '$lib/components/demo-layout/DemoSidebar.svelte';
+	import WebGPUInstructions from '$lib/components/WebGPUInstructions.svelte';
+	import { useWebGPUStatus } from '$lib/composables/useWebGPUStatus.svelte';
 	import '../../app.css';
 
 	import type { Snippet } from 'svelte';
@@ -9,6 +11,9 @@
 	}
 
 	const { children }: Props = $props();
+
+	const webgpu = useWebGPUStatus();
+	const blocked = $derived(!webgpu.isDetecting && !webgpu.available);
 </script>
 
 <div class="flex min-h-screen bg-surface-100-800 text-surface-900-50">
@@ -17,6 +22,31 @@
 
 	<!-- Main Content Area -->
 	<main class="flex-1 overflow-y-auto">
-		{@render children()}
+		{#if webgpu.isDetecting}
+			<div class="flex h-full items-center justify-center p-8">
+				<div class="flex items-center gap-3">
+					<svg class="h-5 w-5 animate-spin text-primary-500" fill="none" viewBox="0 0 24 24">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+						<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+					</svg>
+					<p class="text-surface-500-400">Detecting WebGPU capabilities...</p>
+				</div>
+			</div>
+		{:else if blocked}
+			<div class="flex h-full items-center justify-center p-8">
+				<div class="max-w-lg space-y-4 text-center">
+					<h2 class="text-xl font-bold text-error-500">WebGPU Required</h2>
+					<p class="text-sm text-surface-600-300">
+						The Pixelwise demos require WebGPU. Please enable WebGPU in your browser
+						or switch to a supported browser, then reload the page.
+					</p>
+					{#if webgpu.capabilities}
+						<WebGPUInstructions capabilities={webgpu.capabilities} onRecheck={webgpu.redetect} />
+					{/if}
+				</div>
+			</div>
+		{:else}
+			{@render children()}
+		{/if}
 	</main>
 </div>

--- a/tests/onboarding-wizard.test.ts
+++ b/tests/onboarding-wizard.test.ts
@@ -176,6 +176,32 @@ describe('Onboarding Wizard', () => {
 		});
 	});
 
+	describe('webgpuAvailable field', () => {
+		it('should default to false in new consent', async () => {
+			const { setConsent, getConsent } = await import('$lib/utils/consentStorage');
+
+			setConsent({ acknowledged: false });
+			const consent = getConsent();
+			expect(consent!.webgpuAvailable).toBe(false);
+		});
+
+		it('should be settable via updateWebGPUAvailability', async () => {
+			const { updateWebGPUAvailability, getConsent } = await import('$lib/utils/consentStorage');
+
+			updateWebGPUAvailability(true);
+			expect(getConsent()!.webgpuAvailable).toBe(true);
+		});
+
+		it('should be preserved across setConsent calls', async () => {
+			const { setConsent, updateWebGPUAvailability, getConsent } = await import('$lib/utils/consentStorage');
+
+			updateWebGPUAvailability(true);
+			setConsent({ acknowledged: true });
+
+			expect(getConsent()!.webgpuAvailable).toBe(true);
+		});
+	});
+
 	describe('getConsentAge', () => {
 		it('should return null when no consent', async () => {
 			const { getConsentAge } = await import('$lib/utils/consentStorage');

--- a/tests/webgpu-gate.test.ts
+++ b/tests/webgpu-gate.test.ts
@@ -1,0 +1,106 @@
+/**
+ * WebGPU Gate Enforcement Tests
+ *
+ * Tests for the WebGPU availability gate:
+ *   - shouldBlockDemos() returns correct state based on webgpuAvailable
+ *   - updateWebGPUAvailability() persists to localStorage
+ *   - Gate remains active even after completing onboarding
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+const mockStorage = new Map<string, string>();
+
+Object.defineProperty(globalThis, 'localStorage', {
+	value: {
+		getItem: (key: string) => mockStorage.get(key) ?? null,
+		setItem: (key: string, value: string) => mockStorage.set(key, value),
+		removeItem: (key: string) => mockStorage.delete(key),
+		clear: () => mockStorage.clear()
+	},
+	writable: true
+});
+
+describe('WebGPU Gate', () => {
+	beforeEach(() => {
+		mockStorage.clear();
+	});
+
+	describe('shouldBlockDemos', () => {
+		it('should return false when no consent data exists', async () => {
+			const { shouldBlockDemos } = await import('$lib/utils/consentStorage');
+			// No consent stored = no webgpuAvailable info yet
+			expect(shouldBlockDemos()).toBe(false);
+		});
+
+		it('should return true when webgpuAvailable is false', async () => {
+			const { shouldBlockDemos, setConsent } = await import('$lib/utils/consentStorage');
+
+			setConsent({ acknowledged: true, webgpuAvailable: false });
+			expect(shouldBlockDemos()).toBe(true);
+		});
+
+		it('should return false when webgpuAvailable is true', async () => {
+			const { shouldBlockDemos, setConsent } = await import('$lib/utils/consentStorage');
+
+			setConsent({ acknowledged: true, webgpuAvailable: true });
+			expect(shouldBlockDemos()).toBe(false);
+		});
+
+		it('should still block after completing onboarding without WebGPU', async () => {
+			const { shouldBlockDemos, completeOnboarding, updateWebGPUAvailability } = await import('$lib/utils/consentStorage');
+
+			completeOnboarding();
+			updateWebGPUAvailability(false);
+
+			expect(shouldBlockDemos()).toBe(true);
+		});
+
+		it('should not block after completing onboarding with WebGPU', async () => {
+			const { shouldBlockDemos, completeOnboarding, updateWebGPUAvailability } = await import('$lib/utils/consentStorage');
+
+			completeOnboarding();
+			updateWebGPUAvailability(true);
+
+			expect(shouldBlockDemos()).toBe(false);
+		});
+	});
+
+	describe('updateWebGPUAvailability', () => {
+		it('should persist webgpuAvailable to localStorage', async () => {
+			const { updateWebGPUAvailability, getConsent } = await import('$lib/utils/consentStorage');
+
+			updateWebGPUAvailability(true);
+			const consent = getConsent();
+
+			expect(consent).not.toBeNull();
+			expect(consent!.webgpuAvailable).toBe(true);
+		});
+
+		it('should update existing consent data', async () => {
+			const { updateWebGPUAvailability, setConsent, getConsent } = await import('$lib/utils/consentStorage');
+
+			setConsent({ acknowledged: true, detectedBackend: 'webgpu' });
+			updateWebGPUAvailability(true);
+
+			const consent = getConsent();
+			expect(consent!.acknowledged).toBe(true);
+			expect(consent!.detectedBackend).toBe('webgpu');
+			expect(consent!.webgpuAvailable).toBe(true);
+		});
+
+		it('should toggle from true to false', async () => {
+			const { updateWebGPUAvailability, getConsent } = await import('$lib/utils/consentStorage');
+
+			updateWebGPUAvailability(true);
+			expect(getConsent()!.webgpuAvailable).toBe(true);
+
+			updateWebGPUAvailability(false);
+			expect(getConsent()!.webgpuAvailable).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Non-WebGPU browsers are now blocked by a non-dismissable onboarding modal with browser-specific instructions on enabling WebGPU
- WASM OOM (`Aborted(OOM)`) errors null the unrecoverable Emscripten context and fall through to JS fallback
- Futhark WebGPU `$futhark_context_new` assertion failures produce clearer error messages about GPU driver incompatibility
- Defense-in-depth: demo routes have both a root-layout gate modal and an inline block overlay

## Changes
- `consentStorage.ts` — `webgpuAvailable` field, `shouldBlockDemos()`, `updateWebGPUAvailability()`
- `OnboardingModal.svelte` — `gated` derived state disables close/escape/backdrop/finish
- `demo/+layout.svelte` — inline WebGPU gate with spinner/block/pass states
- `+layout.svelte` — `$effect` re-shows gate modal on `/demo/*` navigation
- `ComputeDispatcher.ts` — OOM catch nulls `futharkContext` in both `computeEsdtFuthark()` and `runFullPipeline()`
- `futhark-webgpu/index.ts` — detect assertion/abort errors in `newFutharkWebGPUContext()`
- 14 new tests across 3 files (gate enforcement, OOM handling, assertion fallback)

## Test plan
- [ ] `pnpm test` passes (766 pass, 26 skipped)
- [ ] Browser with WebGPU: modal dismissable, demos work normally
- [ ] Browser without WebGPU (`--disable-gpu`): modal blocks, demo routes show gate overlay
- [ ] Verify on https://pixelwise.ephemera.xoxd.ai after deploy