### PR TITLE
[codex] Add WebGPU GPU canary

### DIFF
--- a/.github/workflows/webgpu-canary.yml
+++ b/.github/workflows/webgpu-canary.yml
@@ -1,0 +1,119 @@
+name: WebGPU Canary
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - codex/**
+
+concurrency:
+  group: webgpu-canary-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  webgpu-canary:
+    name: Verify WebGPU canary on pixelwise-nix-gpu
+    runs-on: pixelwise-nix-gpu
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Ensure authenticated GitHub flake access
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo 'NIX_CONFIG<<EOF'
+            if [ -n "${NIX_CONFIG:-}" ]; then
+              printf '%s\n' "$NIX_CONFIG"
+            fi
+            echo 'experimental-features = nix-command flakes'
+            echo 'accept-flake-config = true'
+            echo "access-tokens = github.com=${GITHUB_TOKEN}"
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Verify shared GPU runner environment
+        run: |
+          echo "Runner: ${{ runner.name }}"
+          echo "OS: ${{ runner.os }}"
+          uname -a
+          ls -ld /dev/dri /dev/dri/*
+
+      - name: Verify Nix bootstrap
+        run: |
+          command -v nix
+          nix --version
+
+      - name: Verify GPU device contract
+        run: |
+          test -d /dev/dri
+          test -c /dev/dri/card0
+          test -c /dev/dri/renderD128
+
+      - name: Verify Vulkan userspace path
+        run: |
+          nix shell nixpkgs#vulkan-tools nixpkgs#mesa -c bash -lc '
+            set -euo pipefail
+            MESA="$(nix build --no-link --print-out-paths nixpkgs#mesa)"
+            export VK_ICD_FILENAMES="$MESA/share/vulkan/icd.d/radeon_icd.x86_64.json"
+            export LIBGL_DRIVERS_PATH="$MESA/lib/dri"
+            export LD_LIBRARY_PATH="$MESA/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            SUMMARY="$(mktemp)"
+            trap "rm -f \"$SUMMARY\"" EXIT
+            vulkaninfo --summary >"$SUMMARY"
+            echo "### pixelwise WebGPU canary Vulkan summary" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "```text" >> "$GITHUB_STEP_SUMMARY"
+            grep -E "deviceName|deviceType|driverName|driverInfo|apiVersion" "$SUMMARY" | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "```" >> "$GITHUB_STEP_SUMMARY"
+            grep -q "PHYSICAL_DEVICE_TYPE_DISCRETE_GPU" "$SUMMARY"
+          '
+
+      - name: Install dependencies
+        run: |
+          nix shell nixpkgs#nodejs_22 nixpkgs#pnpm --command bash -lc '
+            set -euo pipefail
+            pnpm install --frozen-lockfile
+          '
+
+      - name: Run WebGPU canary
+        run: |
+          nix shell nixpkgs#nodejs_22 nixpkgs#pnpm nixpkgs#chromium nixpkgs#mesa nixpkgs#vulkan-loader --command bash -lc '
+            set -euo pipefail
+            MESA="$(nix build --no-link --print-out-paths nixpkgs#mesa)"
+            VULKAN_LOADER="$(nix build --no-link --print-out-paths nixpkgs#vulkan-loader)"
+            CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)"
+            test -n "$CHROMIUM_BIN"
+            export VK_ICD_FILENAMES="$MESA/share/vulkan/icd.d/radeon_icd.x86_64.json"
+            export LIBGL_DRIVERS_PATH="$MESA/lib/dri"
+            export LD_LIBRARY_PATH="$VULKAN_LOADER/lib:$MESA/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="$CHROMIUM_BIN"
+            pnpm run test:webgpu:canary
+          '
+
+      - name: Publish WebGPU step summary
+        if: always()
+        run: |
+          if [ -f test-results/webgpu-summary.json ]; then
+            echo "### pixelwise WebGPU canary summary" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat test-results/webgpu-summary.json >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: webgpu-canary-artifacts
+          path: |
+            playwright-report-webgpu/
+            test-results/
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -21,18 +21,19 @@
     "node": ">=20.0.0",
     "pnpm": ">=8.0.0"
   },
-  "scripts": {
-    "dev": "vite dev --host 0.0.0.0 --port ${PORT:-5175}",
-    "dev:container": "vite dev --host 0.0.0.0 --port ${PORT:-5175}",
-    "build": "vite build",
-    "preview": "vite preview",
-    "build:futhark": "make -C futhark",
-    "build:futhark:clean": "make -C futhark clean && make -C futhark",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:pixelwise": "vitest run tests/pixelwise/",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
-  },
+	"scripts": {
+		"dev": "vite dev --host 0.0.0.0 --port ${PORT:-5175}",
+		"dev:container": "vite dev --host 0.0.0.0 --port ${PORT:-5175}",
+		"build": "vite build",
+		"preview": "vite preview",
+		"build:futhark": "make -C futhark",
+		"build:futhark:clean": "make -C futhark clean && make -C futhark",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"test:pixelwise": "vitest run tests/pixelwise/",
+		"test:webgpu:canary": "playwright test -c playwright.webgpu.config.ts",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+	},
   "devDependencies": {
     "@playwright/test": "^1.54.1",
     "@sveltejs/adapter-node": "^5.5.2",

--- a/playwright.webgpu.config.ts
+++ b/playwright.webgpu.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: './tests',
+	testMatch: '**/webgpu-canary.spec.ts',
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: 1,
+	timeout: 120_000,
+	expect: {
+		timeout: 60_000
+	},
+	reporter: [
+		['html', { outputFolder: 'playwright-report-webgpu' }],
+		['json', { outputFile: 'test-results/webgpu-results.json' }],
+		['list']
+	],
+	use: {
+		baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173',
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+		video: 'off'
+	},
+	projects: [
+		{
+			name: 'chromium-webgpu',
+			use: {
+				...devices['Desktop Chrome'],
+				viewport: { width: 1440, height: 960 },
+				launchOptions: {
+					executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+					args: [
+						'--enable-unsafe-webgpu',
+						'--enable-features=Vulkan',
+						'--ignore-gpu-blocklist',
+						'--use-angle=vulkan'
+					]
+				}
+			}
+		}
+	],
+	webServer: process.env.CI
+		? {
+				command: 'PORT=5173 pnpm run dev',
+				port: 5173,
+				reuseExistingServer: false,
+				timeout: 120_000
+			}
+		: undefined
+});

--- a/tests/webgpu-canary.spec.ts
+++ b/tests/webgpu-canary.spec.ts
@@ -1,0 +1,209 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { expect, test } from '@playwright/test';
+
+const SOFTWARE_TOKENS = ['llvmpipe', 'lavapipe', 'softpipe', 'swiftshader'];
+
+test('should expose a real WebGPU adapter on the GPU runner lane', async ({ page }, testInfo) => {
+	const consoleErrors: string[] = [];
+	const pageErrors: string[] = [];
+	let pageCrashed = false;
+	let pageClosed = false;
+	let uiState: {
+		locationPath: string | null;
+		responseOk: boolean | null;
+		documentTitle: string | null;
+		bodyTextSample: string | null;
+		bodyChildCount: number | null;
+		documentReadyState: string | null;
+		hasNavigatorGpu: boolean | null;
+		bodyHtmlSample: string | null;
+	} = {
+		locationPath: null,
+		responseOk: null,
+		documentTitle: null,
+		bodyTextSample: null,
+		bodyChildCount: null,
+		documentReadyState: null,
+		hasNavigatorGpu: null,
+		bodyHtmlSample: null
+	};
+	let appCapabilities: Record<string, unknown> | null = null;
+	let runtimeSummary: Record<string, unknown> | null = null;
+
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') {
+			consoleErrors.push(msg.text());
+		}
+	});
+	page.on('pageerror', (error) => {
+		pageErrors.push(String(error));
+	});
+	page.on('crash', () => {
+		pageCrashed = true;
+	});
+	page.on('close', () => {
+		pageClosed = true;
+	});
+
+	try {
+		const response = await page.goto('/');
+
+		const shellState = await page.evaluate(() => ({
+			documentTitle: document.title,
+			bodyTextSample: document.body.innerText.trim().slice(0, 400),
+			bodyChildCount: document.body.childElementCount,
+			documentReadyState: document.readyState,
+			hasNavigatorGpu: typeof navigator.gpu !== 'undefined',
+			bodyHtmlSample: document.body.innerHTML.slice(0, 1200)
+		}));
+
+		expect(response?.ok()).toBe(true);
+		expect(new URL(page.url()).pathname).toBe('/');
+
+		uiState = {
+			locationPath: new URL(page.url()).pathname,
+			responseOk: response?.ok() ?? null,
+			documentTitle: shellState.documentTitle || null,
+			bodyTextSample: shellState.bodyTextSample || null,
+			bodyChildCount: shellState.bodyChildCount,
+			documentReadyState: shellState.documentReadyState || null,
+			hasNavigatorGpu: shellState.hasNavigatorGpu,
+			bodyHtmlSample: shellState.bodyHtmlSample || null
+		};
+
+		appCapabilities = await page.evaluate(async () => {
+			const featureDetection = await import('/src/lib/pixelwise/featureDetection.ts');
+			featureDetection.clearCapabilitiesCache();
+			const caps = await featureDetection.getCapabilitiesAsync();
+
+			return {
+				webgpu: caps.webgpu,
+				webgpuAdapter: caps.webgpuAdapter,
+				recommendedMode: caps.recommendedMode,
+				sharedArrayBuffer: caps.sharedArrayBuffer,
+				wasm: caps.wasm,
+				wasmSimd: caps.wasmSimd,
+				importExternalTexture: caps.importExternalTexture,
+				copyExternalImage: caps.copyExternalImage,
+				videoFrameCallback: caps.videoFrameCallback,
+				mediaStreamTrackProcessor: caps.mediaStreamTrackProcessor,
+				gpuTier: caps.gpuTier
+			};
+		});
+
+		runtimeSummary = await page.evaluate(async () => {
+			const summary = {
+				navigatorGpu: typeof navigator.gpu !== 'undefined',
+				secureContext: window.isSecureContext,
+				crossOriginIsolated:
+					typeof globalThis.crossOriginIsolated !== 'undefined' ? globalThis.crossOriginIsolated : false,
+				adapterAcquired: false,
+				adapterInfoText: null as string | null,
+				isFallbackAdapter: null as boolean | null,
+				deviceRequestSucceeded: false,
+				deviceRequestError: null as string | null
+			};
+
+			if (!navigator.gpu) {
+				return summary;
+			}
+
+			let adapter =
+				(await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' })) ??
+				(await navigator.gpu.requestAdapter());
+
+			if (!adapter) {
+				return summary;
+			}
+
+			summary.adapterAcquired = true;
+
+			const adapterAny = adapter as unknown as Record<string, unknown>;
+			summary.isFallbackAdapter =
+				typeof adapterAny.isFallbackAdapter === 'boolean'
+					? adapterAny.isFallbackAdapter
+					: typeof adapterAny.is_fallback_adapter === 'boolean'
+						? (adapterAny.is_fallback_adapter as boolean)
+						: null;
+
+			if (typeof adapterAny.requestAdapterInfo === 'function') {
+				try {
+					const info = await (
+						adapterAny.requestAdapterInfo as unknown as (this: GPUAdapter) => Promise<Record<string, unknown>>
+					).call(adapter);
+					summary.adapterInfoText = ['vendor', 'architecture', 'device', 'description']
+						.map((key) => info[key])
+						.filter((value): value is string => typeof value === 'string' && value.length > 0)
+						.join(' ');
+				} catch (error) {
+					summary.deviceRequestError = `requestAdapterInfo failed: ${String(error)}`;
+				}
+			}
+
+			try {
+				const device = await adapter.requestDevice({
+					requiredFeatures: [],
+					requiredLimits: {
+						maxBufferSize: 256 * 1024 * 1024
+					}
+				});
+				const testBuffer = device.createBuffer({
+					size: 256,
+					usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
+					mappedAtCreation: true
+				});
+				testBuffer.unmap();
+				testBuffer.destroy();
+				device.destroy();
+				summary.deviceRequestSucceeded = true;
+			} catch (error) {
+				summary.deviceRequestError = String(error);
+			}
+
+			return summary;
+		});
+
+		expect(appCapabilities.webgpu).toBe(true);
+		expect(appCapabilities.recommendedMode).toBe('webgpu');
+		expect(appCapabilities.webgpuAdapter).not.toBeNull();
+		expect(runtimeSummary.navigatorGpu).toBe(true);
+		expect(runtimeSummary.secureContext).toBe(true);
+		expect(runtimeSummary.adapterAcquired).toBe(true);
+		expect(runtimeSummary.isFallbackAdapter).not.toBe(true);
+		expect(runtimeSummary.deviceRequestSucceeded).toBe(true);
+
+		const adapterText = [
+			String(appCapabilities.webgpuAdapter ?? ''),
+			String(runtimeSummary.adapterInfoText ?? '')
+		]
+			.join(' ')
+			.toLowerCase();
+
+		for (const token of SOFTWARE_TOKENS) {
+			expect(adapterText).not.toContain(token);
+		}
+
+		const relevantConsoleErrors = consoleErrors.filter((message) =>
+			/webgpu|gpu|adapter|dawn|vulkan/i.test(message)
+		);
+		expect(relevantConsoleErrors).toEqual([]);
+		expect(pageErrors).toEqual([]);
+	} finally {
+		const summary = {
+			uiState,
+			appCapabilities,
+			runtimeSummary,
+			consoleErrors,
+			pageErrors,
+			pageCrashed,
+			pageClosed
+		};
+
+		await mkdir('test-results', { recursive: true });
+		await writeFile('test-results/webgpu-summary.json', JSON.stringify(summary, null, 2));
+		await testInfo.attach('webgpu-summary', {
+			body: JSON.stringify(summary, null, 2),
+			contentType: 'application/json'
+		});
+	}
+});


### PR DESCRIPTION
## What changed
- added a dedicated `playwright.webgpu.config.ts` and `tests/webgpu-canary.spec.ts` for one bounded Chromium WebGPU smoke
- added a `WebGPU Canary` workflow on `tinyland-nix-gpu` with Vulkan userspace verification and Playwright artifact upload
- added `test:webgpu:canary` to `package.json`
- removed the stale root `runed` importer entry from `pnpm-lock.yaml` so `pnpm install --frozen-lockfile` works again

## Why
`pixelwise-research` is the first real downstream repo here with app-owned WebGPU runtime code. It needs a default-branch canary on the shared GPU lane instead of relying on upstream runner proof alone.

## Impact
This gives the repo a bounded, operator-readable WebGPU proof surface on `tinyland-nix-gpu` without broadening the existing general verification matrix.

## Validation
- `git diff --check`
- `nix shell nixpkgs#nodejs_22 nixpkgs#nodePackages.pnpm --command bash -lc 'pnpm install --frozen-lockfile && pnpm exec playwright test -c playwright.webgpu.config.ts --list'`
